### PR TITLE
Updated (fix) utility.get_path

### DIFF
--- a/python/utility.py
+++ b/python/utility.py
@@ -28,6 +28,7 @@ def get_all_symbols(type):
 
 def download_file(base_path, file_name, date_range=None, folder=None):
   download_path = "{}{}".format(base_path, file_name)
+  base_path = base_path.replace("?prefix=", "")
   if folder:
     base_path = os.path.join(folder, base_path)
   if date_range:
@@ -100,9 +101,9 @@ def check_directory(arg_value):
   return arg_value
 
 def get_path(trading_type, market_data_type, time_period, symbol, interval=None):
-  trading_type_path = 'data/spot'
+  trading_type_path = '?prefix=data/spot'
   if trading_type != 'spot':
-    trading_type_path = f'data/futures/{trading_type}'
+    trading_type_path = f'?prefix=data/futures/{trading_type}'
   if interval is not None:
     path = f'{trading_type_path}/{time_period}/{market_data_type}/{symbol.upper()}/{interval}/'
   else:


### PR DESCRIPTION
Updated `utility.get_path` by prepending '?prefix=' to `trading_type_path` which in turn fixes the `download_url` used in `utility.download_file`. Without this fix, `utility.download_file` was throwing `urllib.error.HTTPError`.

Decided to add line 31 in `utility.download_file` to allow the folder paths to stay consistent with what is prior to this update.