### PR TITLE
Fix examples formatting in python README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -43,6 +43,9 @@ This will show the arguments that can be parsed to the scripts which can be used
 | -c              | 1 to download **checksum file**, default 0       | 
 | -i              | single kline **interval** or multiple **intervals** separated by space      |
 | -t              | Trading type: **spot**, **um** (USD-M Futures), **cm** (COIN-M Futures)    |
+
+### Examples 
+
 e.g download Futures BTCUSDT um indexPriceKlines
 `python3 download-indexPriceKlines.py -s BTCUSDT -t um`
 


### PR DESCRIPTION
Fixed the broken formatting of the examples in the `python/README.md`

## Before
![image](https://user-images.githubusercontent.com/28054628/169957035-ffd9dfca-44f1-4ad6-b3e9-31141de30959.png)

## After
![image](https://user-images.githubusercontent.com/28054628/169956997-22c475d2-9fc5-4bd7-b21e-b537801fa7f9.png)
