### PR TITLE
add a python script for downloading funding rates

### DIFF
--- a/python/download-futures-fundingRates.py
+++ b/python/download-futures-fundingRates.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+"""
+  script to download fundingRate.
+  set the absolute path destination folder for STORE_DIRECTORY, and run
+
+  e.g. STORE_DIRECTORY=/data/ ./download-kline.py
+
+"""
+import sys
+from datetime import *
+import pandas as pd
+from enums import *
+from utility import download_file, get_all_symbols, get_parser, get_start_end_date_objects, convert_to_date_object, \
+  get_path
+
+
+def download_monthly_fundingRate(trading_type, symbols, num_symbols, intervals, years, months, start_date, end_date, folder, checksum):
+  current = 0
+  date_range = None
+
+  if start_date and end_date:
+    date_range = start_date + " " + end_date
+
+  if not start_date:
+    start_date = START_DATE
+  else:
+    start_date = convert_to_date_object(start_date)
+
+  if not end_date:
+    end_date = END_DATE
+  else:
+    end_date = convert_to_date_object(end_date)
+
+  print("Found {} symbols".format(num_symbols))
+
+  for symbol in symbols:
+    print("[{}/{}] - start download monthly {} fundingRate ".format(current+1, num_symbols, symbol))
+    for year in years:
+      for month in months:
+        current_date = convert_to_date_object('{}-{}-01'.format(year, month))
+        if current_date >= start_date and current_date <= end_date:
+          path = get_path(trading_type, "fundingRate", "monthly", symbol)
+          file_name = "{}-{}-{}-{}.zip".format(symbol.upper(), "fundingRate", year, '{:02d}'.format(month))
+          download_file(path, file_name, date_range, folder)
+
+          if checksum == 1:
+            checksum_path = get_path(trading_type, "fundingRate", "monthly", symbol)
+            checksum_file_name = "{}-{}-{}-{}.zip.CHECKSUM".format(symbol.upper(), "fundingRate", year, '{:02d}'.format(month))
+            download_file(checksum_path, checksum_file_name, date_range, folder)
+
+    current += 1
+
+def download_daily_fundingRate(trading_type, symbols, num_symbols, intervals, dates, start_date, end_date, folder, checksum):
+  current = 0
+  date_range = None
+
+  if start_date and end_date:
+    date_range = start_date + " " + end_date
+
+  if not start_date:
+    start_date = START_DATE
+  else:
+    start_date = convert_to_date_object(start_date)
+
+  if not end_date:
+    end_date = END_DATE
+  else:
+    end_date = convert_to_date_object(end_date)
+
+  #Get valid intervals for daily
+  intervals = list(set(intervals) & set(DAILY_INTERVALS))
+  print("Found {} symbols".format(num_symbols))
+
+  for symbol in symbols:
+    print("[{}/{}] - start download daily {} fundingRate ".format(current+1, num_symbols, symbol))
+    
+    for date in dates:
+      current_date = convert_to_date_object(date)
+      if current_date >= start_date and current_date <= end_date:
+        path = get_path(trading_type, "fundingRate", "daily", symbol)
+        file_name = "{}-{}-{}.zip".format(symbol.upper(), "fundingRate", date)
+        download_file(path, file_name, date_range, folder)
+
+        if checksum == 1:
+          checksum_path = get_path(trading_type, "fundingRate", "daily", symbol)
+          checksum_file_name = "{}-{}-{}.zip.CHECKSUM".format(symbol.upper(), "fundingRate", date)
+          download_file(checksum_path, checksum_file_name, date_range, folder)
+
+    current += 1
+
+if __name__ == "__main__":
+    parser = get_parser('fundingRate')
+    args = parser.parse_args(sys.argv[1:])
+
+    if not args.symbols:
+      print("fetching all symbols from exchange")
+      symbols = get_all_symbols(args.type)
+      num_symbols = len(symbols)
+    else:
+      symbols = args.symbols
+      num_symbols = len(symbols)
+
+    if args.dates:
+      dates = args.dates
+    else:
+      period = convert_to_date_object(datetime.today().strftime('%Y-%m-%d')) - convert_to_date_object(
+        PERIOD_START_DATE)
+      dates = pd.date_range(end=datetime.today(), periods=period.days + 1).to_pydatetime().tolist()
+      dates = [date.strftime("%Y-%m-%d") for date in dates]
+      if args.skip_monthly == 0:
+        download_monthly_fundingRate(args.type, symbols, num_symbols, None, args.years, args.months, args.startDate, args.endDate, args.folder, args.checksum)
+    if args.skip_daily == 0:
+      download_daily_fundingRate(args.type, symbols, num_symbols, None, dates, args.startDate, args.endDate, args.folder, args.checksum)
+


### PR DESCRIPTION
This pull request introduces a Python script for downloading funding rates.
The script's argparse arguments align with those in existing scripts, with the exception that it omits an 'interval' argument.