### PR TITLE
fix(utility): Support downloading trading instruments with Chinese names

### DIFF
--- a/python/utility.py
+++ b/python/utility.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 from datetime import *
 import urllib.request
+from urllib.parse import quote
 from argparse import ArgumentParser, RawTextHelpFormatter, ArgumentTypeError
 from enums import *
 
@@ -15,7 +16,9 @@ def get_destination_dir(file_url, folder=None):
   return os.path.join(store_directory, file_url)
 
 def get_download_url(file_url):
-  return "{}{}".format(BASE_URL, file_url)
+  # Ensure the URL is properly encoded to handle Chinese characters
+  encoded_url = quote(file_url, safe='/')
+  return "{}{}".format(BASE_URL, encoded_url)
 
 def get_all_symbols(type):
   if type == 'um':


### PR DESCRIPTION
Support downloading trading instruments with Chinese characters, e.g., 币安人生USDT